### PR TITLE
Set initial width/height to the width/height of the positionconfig, if available

### DIFF
--- a/src/NineSlice.js
+++ b/src/NineSlice.js
@@ -75,7 +75,9 @@ export default class NineSlice extends Phaser.GameObjects.RenderTexture {
    *    and height will be computed from the source texture.
    */
   constructor(scene, _sliceConfig, positionConfig = null) {
-    super(scene, 0, 0, 32, 32)
+    const {x, y, width, height} = positionConfig
+
+    super(scene, 0, 0, width || 32, height || 32)
 
     this.initFrames = this.initFrames.bind(this)
     this.getUsableBounds = this.getUsableBounds.bind(this)
@@ -118,7 +120,6 @@ export default class NineSlice extends Phaser.GameObjects.RenderTexture {
     // we can unblock a bunch of the NineSlice specific stuff.
     this._initalized = true
 
-    const {x, y, width, height} = positionConfig
     this.setPosition(x || 0, y || 0)
     this.resize(
       width || this.sourceFrame.width,


### PR DESCRIPTION
With the upgrade from phaser 3.16.x to 3.17.0, this plugin did not render correctly anymore, it scaled the rendertexture weirdly. I discovered that if the initial width was set in the constructor, the element did render normally. This isn't really a fix of the problem if you do not set the width and height through `positionConfig` though. The source of the problem has something to do with the combination of the resize method and webgl renderer of the rendertexture, but I could not find out in the limited time I had what the source of that problem was.

This fix however will make the plugin usable in phaser 3.17 if you do set width/height in `positionConfig`