### PR TITLE
typescript-support-for-sprites-within-atlases

### DIFF
--- a/nineslice.d.ts
+++ b/nineslice.d.ts
@@ -116,6 +116,9 @@ declare namespace Phaser.GameObjects {
          */
         nineslice(x: number, y: number, width: number, height: number, key: string,
             nonUniform: number[]): Phaser.GameObjects.RenderTexture;
+
+        nineslice(x: number, y: number, width: number, height: number, { key: string, frame: any },
+            nonUniform: number[]): Phaser.GameObjects.RenderTexture;
     }
 
     // TODO: .make.nineslice return type & argument types


### PR DESCRIPTION
- Add typescript support for 9 slice sprites that are within atlases