### PR TITLE
Move webpack-cli out of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "flow-bin": "^0.55.0",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.9"
   },
   "scripts": {
@@ -32,8 +33,7 @@
     "lint:fix": "eslint src/**.js --fix"
   },
   "dependencies": {
-    "phaser": "^3.13.0",
-    "webpack-cli": "^3.1.1"
+    "phaser": "^3.13.0"
   },
   "keywords": [
     "phaser",


### PR DESCRIPTION
Webpack is not required as a dependency, only as a build step. Keep it in dev dependencies.

I'm building a phaser app with [parceljs](https://parceljs.org/) and it's working fine, but I get an annoying warning about one of the peer dependencies of `webpack-cli`: 
```
warning "phaser3-nineslice > webpack-cli@3.3.10" has unmet peer dependency "webpack@4.x.x".
```

Moving the `webpack-cli` to `devDependencies` would fix this.