### PR TITLE
Typescript support for atlas syntax

### DIFF
--- a/nineslice.d.ts
+++ b/nineslice.d.ts
@@ -86,7 +86,7 @@ declare namespace Phaser.GameObjects {
          * if you would like to specify a frame within a spritesheet or atlas indicated 
          * by `key`.
          */
-        nineslice(x: number, y: number, width: number, height: number, key: string,
+        nineslice(x: number, y: number, width: number, height: number, key: string | { key: string, frame: string | number },
             offset: number, safeArea?: number): Phaser.GameObjects.RenderTexture;
 
         /**


### PR DESCRIPTION
While the plugin supports using atlases, the typescript thought it was invalid syntax.

This fixes it.